### PR TITLE
add : dir to cloudbuild.yaml

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,7 @@
  # Build the container image
  - name: 'gcr.io/cloud-builders/docker'
    args: ['build', '-t', 'gcr.io/$PROJECT_ID/curio-nest:$COMMIT_SHA', '.']
+   dir: 'server'
  # Push the container image to Container Registry
  - name: 'gcr.io/cloud-builders/docker'
    args: ['push', 'gcr.io/$PROJECT_ID/curio-nest:$COMMIT_SHA']


### PR DESCRIPTION
cloudbuild.yamlのbuild工程に、以下の記述を追加。

dir : 'server'
でserverディレクトリを指定