### PR TITLE
fix : Error (failed to listen on the port 8080)

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -18,6 +18,7 @@ RUN yarn build
 FROM node:18.16.0-alpine3.17 AS runner
 
 ENV NODE_ENV=production
+ENV PORT=8080
 
 EXPOSE 8080 
 


### PR DESCRIPTION
以下のエラーを解消するために、Dockerfileに
**EXPOSE 8080**
を追記。

### エラー文
「ERROR: (gcloud.run.deploy) The user-provided container failed to start and listen on the port defined provided by the PORT=8080 environment variable.」